### PR TITLE
impl Error for ParseError

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -70,6 +70,24 @@ impl From<RecordParseError> for ParseError {
     }
 }
 
+impl Error for ParseError {
+    fn description(&self) -> &str {
+        match self {
+            &ParseError::IOError(ref err) => err.description(),
+            &ParseError::RecordParseError(ref err) => err.description(),
+        }
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, formatter: &mut Formatter) -> FormatResult {
+        match self {
+            &ParseError::IOError(ref err) => err.fmt(formatter),
+            &ParseError::RecordParseError(ref err) => err.fmt(formatter),
+        }
+    }
+}
+
 /// Parse the record one line at a time
 ///
 /// # Examples


### PR DESCRIPTION
This makes it easier to handle errors returned from `LCOVParser`.