### PR TITLE
Change `lcov_parser::merge_files` behavior to accept info files without checksums

### DIFF
--- a/src/merger/merger.rs
+++ b/src/merger/merger.rs
@@ -145,6 +145,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn merge_checksum_error() {
         let report_path = "tests/fixtures/merge/without_checksum_fixture.info";
         let mut parse = ReportMerger::new();

--- a/src/report/line.rs
+++ b/src/report/line.rs
@@ -80,15 +80,16 @@ impl<'a> TryMerge<&'a Line> for Line {
     type Err = ChecksumError;
 
     fn try_merge(&mut self, other: &'a Line) -> MergeResult<Self::Err> {
-        if !other.has_checkshum() {
-            return Err(ChecksumError::Empty(MergeLine::from(other)));
-        }
-
-        if self.checksum.as_ref() != other.checksum() {
-            return Err(ChecksumError::Mismatch(
-                MergeLine::from(&self.clone()),
-                MergeLine::from(other)
-            ));
+        if let Some(o) = other.checksum() {
+            if let Some(ref s) = self.checksum {
+                if s != o {
+                    return Err(ChecksumError::Mismatch(
+                        MergeLine::from(&self.clone()),
+                        MergeLine::from(other)
+                    ));
+                }
+            }
+            self.checksum = Some(o.clone());
         }
         self.execution_count += *other.execution_count();
         Ok(())


### PR DESCRIPTION
The old behavior of the function is too strict to reject the input
files that are accepted by lcov. In the original lcov implementation,
checksum validation is performed only when both side of the lines have
checksum. This commit changes `lcov_parser::merge_files` behaviour
to be the same as original implementation.

The old behavior of `lcov_parser::merge_files` have another problem.
If you follow the recommended procedure written in the lcov manpage,
the output file is not mergeable with `lcov_parser::merge_files`.

lcov manpage[1] saids:

    Recommended procedure when capturing data for a test case:

    1. create baseline coverage data file
           # lcov -c -i -d appdir -o app_base.info

    2. perform test
           # appdir/test

    3. create test coverage data file
           # lcov -c -d appdir -o app_test.info

    4. combine baseline and test coverage data
           #   lcov   -a   app_base.info   -a    app_test.info    -o
           app_total.info

The information file created by 1 does not contain checksum even if `--checksum` option is given
(See my Gist[2] for the output files). With using `lcov_parser::merge_files`,
merging `app_base.info` and `app_test.info` will be failed due to lack of the checksum information.

[1]: http://ltp.sourceforge.net/coverage/lcov/lcov.1.php
[2]: https://gist.github.com/anonymous/253ce68d08f398aec2493a32093ebc62